### PR TITLE
fix: output message missing curly brackets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Echo Action
       run: |
-        echo "Capturing metrics for action: ${action_name} and sending to ADX"
+        echo "Capturing metrics for action: ${{ action_name }} and sending to ADX"
       shell: bash
 
     - name: Get action metrics


### PR DESCRIPTION
I noticed the action name is blank on the output message. Looks proper for the actual post to the backend.

Signed-off-by: JasonWalker <Jason.Walker1@aa.com>