### PR TITLE
fix: use context for input values

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Echo Action
       run: |
-        echo "Capturing metrics for action: ${ action_name } and sending to ADX"
+        echo "Capturing metrics for action: ${{ inputs.action_name }} and sending to ADX"
       shell: bash
 
     - name: Get action metrics


### PR DESCRIPTION
#3 broke builds from not having the correct context where `action_name` actually lives. The Action just didn't know.

This uses the correct context (`inputs.`) so Actions knows where the value is stored

Signed-off-by: JasonWalker <Jason.Walker1@aa.com>